### PR TITLE
Feature/member

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,25 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/lion/studypartner/domain/member/controller/MemberController.java
+++ b/src/main/java/lion/studypartner/domain/member/controller/MemberController.java
@@ -1,0 +1,33 @@
+package lion.studypartner.domain.member.controller;
+
+import jakarta.validation.Valid;
+import lion.studypartner.domain.member.dto.MemberRequest;
+import lion.studypartner.domain.member.dto.MemberResponse;
+import lion.studypartner.domain.member.service.MemberService;
+import lion.studypartner.global.security.TokenDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MemberController {
+
+  private final MemberService memberService;
+
+  @PostMapping("/members/signup")
+  public ResponseEntity<MemberResponse> signUp(@Valid @RequestBody MemberRequest.SignUp request) {
+
+    return ResponseEntity.ok(memberService.signUp(request));
+  }
+
+  @PostMapping("/members/signin")
+  public ResponseEntity<TokenDto> signIn(@Valid @RequestBody MemberRequest.SignIn request) {
+
+    return ResponseEntity.ok(memberService.signIn(request));
+  }
+}

--- a/src/main/java/lion/studypartner/domain/member/dto/MemberRequest.java
+++ b/src/main/java/lion/studypartner/domain/member/dto/MemberRequest.java
@@ -1,0 +1,62 @@
+package lion.studypartner.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.Date;
+import lion.studypartner.global.type.EducationType;
+import lombok.Builder;
+import lombok.Getter;
+
+public class MemberRequest {
+
+  @Getter
+  @Builder
+  public static class SignUp {
+
+    @Size(min = 2, max = 15, message = "이름을 2~15글자 사이로 입력해주세요.")
+    private String name;
+
+    @Email(message = "메일을 확인해주세요.")
+    private String email;
+
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[$@!%*?&])[A-Za-z\\d$@!%*?&]{8,15}", message = "비밀번호는 8자 이상 15자 이하로, 소문자, 대문자, 숫자 및 특수문자를 모두 포함해야 합니다.")
+    private String password;
+
+    @Past(message = "생일을 오늘보다 과거일자로 입력해주세요.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private Date birthDate;
+
+    private EducationType education;
+    private boolean alarmEnabled;
+
+    public SignUp(String name, String email, String password, Date birthDate,
+        EducationType education, boolean alarmEnabled) {
+      this.name = name;
+      this.email = email;
+      this.password = password;
+      this.birthDate = birthDate;
+      this.education = education;
+      this.alarmEnabled = alarmEnabled;
+    }
+  }
+
+  @Getter
+  @Builder
+  public static class SignIn {
+
+    @NotNull(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @NotNull(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    public SignIn(String email, String password) {
+      this.email = email;
+      this.password = password;
+    }
+  }
+}

--- a/src/main/java/lion/studypartner/domain/member/dto/MemberResponse.java
+++ b/src/main/java/lion/studypartner/domain/member/dto/MemberResponse.java
@@ -1,0 +1,43 @@
+package lion.studypartner.domain.member.dto;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import lion.studypartner.domain.member.entity.Member;
+import lion.studypartner.global.type.EducationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberResponse {
+
+  private Long id;
+  private String name;
+  private String email;
+  private Date birthDate;
+  private boolean alarmEnabled;
+  private String imageUrl;
+  private EducationType education;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private LocalDateTime deletedAt;
+
+  public static MemberResponse from(Member member) {
+    return MemberResponse.builder()
+        .id(member.getId())
+        .name(member.getName())
+        .email(member.getEmail())
+        .birthDate(member.getBirthDate())
+        .alarmEnabled(member.isAlarmEnabled())
+        .imageUrl(member.getImageUrl())
+        .education(member.getEducation())
+        .createdAt(member.getCreatedAt())
+        .updatedAt(member.getUpdatedAt())
+        .deletedAt(member.getDeletedAt())
+        .build();
+  }
+}

--- a/src/main/java/lion/studypartner/domain/member/entity/Member.java
+++ b/src/main/java/lion/studypartner/domain/member/entity/Member.java
@@ -1,0 +1,73 @@
+package lion.studypartner.domain.member.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import java.util.Date;
+import lion.studypartner.domain.member.dto.MemberRequest;
+import lion.studypartner.global.type.EducationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE member SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+public class Member {
+
+  @Setter
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Setter
+  private String name;
+
+  @Setter
+  private String email;
+
+  @Setter
+  private String password;
+  private Date birthDate;
+
+  @Setter
+  private boolean alarmEnabled;
+
+  @Setter
+  private String imageUrl;
+
+  @Setter
+  private EducationType education;
+
+  @CreationTimestamp
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  private LocalDateTime updatedAt;
+
+  private LocalDateTime deletedAt;
+
+  @Setter
+  private String refreshToken;
+
+  public static Member from(MemberRequest.SignUp request) {
+    return Member.builder()
+        .name(request.getName())
+        .email(request.getEmail())
+        .birthDate(request.getBirthDate())
+        .alarmEnabled(request.isAlarmEnabled())
+        .build();
+  }
+}

--- a/src/main/java/lion/studypartner/domain/member/repository/MemberRepository.java
+++ b/src/main/java/lion/studypartner/domain/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package lion.studypartner.domain.member.repository;
+
+import java.util.Optional;
+import lion.studypartner.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+  Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/lion/studypartner/domain/member/service/MemberService.java
+++ b/src/main/java/lion/studypartner/domain/member/service/MemberService.java
@@ -1,0 +1,54 @@
+package lion.studypartner.domain.member.service;
+
+import lion.studypartner.domain.member.dto.MemberRequest.SignIn;
+import lion.studypartner.domain.member.dto.MemberRequest.SignUp;
+import lion.studypartner.domain.member.dto.MemberResponse;
+import lion.studypartner.domain.member.entity.Member;
+import lion.studypartner.domain.member.repository.MemberRepository;
+import lion.studypartner.global.expeciton.CustomException;
+import lion.studypartner.global.expeciton.ErrorCode;
+import lion.studypartner.global.security.JwtProvider;
+import lion.studypartner.global.security.TokenDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+  private final MemberRepository memberRepository;
+  private final BCryptPasswordEncoder bCryptPasswordEncoder;
+  private final JwtProvider jwtProvider;
+
+  public MemberResponse signUp(SignUp request) {
+    if (memberRepository.findByEmail(request.getEmail()).isPresent()) {
+      throw new CustomException(ErrorCode.EMAIL_EXIST);
+    }
+
+    Member member = Member.from(request);
+    member.setPassword(bCryptPasswordEncoder.encode(request.getPassword()));
+
+    return MemberResponse.from(memberRepository.save(member));
+  }
+
+  public TokenDto signIn(SignIn request) {
+    Member member = memberRepository.findByEmail(request.getEmail())
+        .orElseThrow(() -> new CustomException(ErrorCode.LOGIN_FAIL));
+
+    if (!bCryptPasswordEncoder.matches(request.getPassword(), member.getPassword())) {
+      throw new CustomException(ErrorCode.LOGIN_FAIL);
+    }
+
+    String accessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail());
+    String refreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmail());
+
+    member.setRefreshToken(refreshToken);
+    memberRepository.save(member);
+
+    return TokenDto.builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .build();
+  }
+}

--- a/src/main/java/lion/studypartner/global/config/SecurityConfig.java
+++ b/src/main/java/lion/studypartner/global/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package lion.studypartner.global.config;
+
+import lion.studypartner.global.security.JwtFilter;
+import lion.studypartner.global.security.JwtProvider;
+import lion.studypartner.global.security.MemberDetailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final JwtProvider jwtProvider;
+  private final MemberDetailService memberDetailService;
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+    http
+        .cors(Customizer.withDefaults())
+        .csrf(csrf -> csrf.disable())
+        .authorizeHttpRequests((auth) -> auth
+            .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/signin",
+                "/api/members/signup").permitAll()
+            .requestMatchers("/**").permitAll()
+            .anyRequest().authenticated()
+        );
+    http
+        .addFilterBefore(new JwtFilter(jwtProvider, memberDetailService),
+            UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
+  }
+
+  @Bean
+  public BCryptPasswordEncoder bCryptPasswordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/lion/studypartner/global/expeciton/CustomException.java
+++ b/src/main/java/lion/studypartner/global/expeciton/CustomException.java
@@ -1,0 +1,15 @@
+package lion.studypartner.global.expeciton;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public CustomException(ErrorCode errorCode) {
+
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/lion/studypartner/global/expeciton/CustomExceptionHandler.java
+++ b/src/main/java/lion/studypartner/global/expeciton/CustomExceptionHandler.java
@@ -1,0 +1,40 @@
+package lion.studypartner.global.expeciton;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class CustomExceptionHandler {
+
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<String> customExceptionHandler(final CustomException e) {
+
+    return ResponseEntity.status(e.getErrorCode().getStatus()).body(e.getErrorCode().getMessage());
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<String> processValidationError(MethodArgumentNotValidException e) {
+
+    String errorMessage = e.getBindingResult().getFieldErrors()
+        .stream().map(DefaultMessageSourceResolvable::getDefaultMessage).toList().get(0);
+
+    return ResponseEntity.badRequest().body(errorMessage);
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, String>> handleIllegalArgumentException(
+      IllegalArgumentException e) {
+    Map<String, String> response = new HashMap<>();
+    response.put("error", e.getMessage());
+
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+  }
+}

--- a/src/main/java/lion/studypartner/global/expeciton/ErrorCode.java
+++ b/src/main/java/lion/studypartner/global/expeciton/ErrorCode.java
@@ -1,0 +1,16 @@
+package lion.studypartner.global.expeciton;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+  EMAIL_EXIST("이미 가입된 메일입니다.", HttpStatus.BAD_REQUEST),
+  LOGIN_FAIL("이메일, 비밀번호를 확인해 주세요.", HttpStatus.BAD_REQUEST);
+
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/lion/studypartner/global/security/JwtFilter.java
+++ b/src/main/java/lion/studypartner/global/security/JwtFilter.java
@@ -1,0 +1,60 @@
+package lion.studypartner.global.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+  private final JwtProvider jwtProvider;
+  private final MemberDetailService memberDetailService;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String token = request.getHeader("Access-Token");
+
+    if (StringUtils.hasText(token)) {
+
+      try {
+        MemberDetail memberDetail = memberDetailService.loadUserByUsername(
+            jwtProvider.getEmail(token));
+
+        Authentication auth =
+            new UsernamePasswordAuthenticationToken(
+                memberDetail, null, memberDetail.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+      } catch (SignatureException | UnsupportedJwtException | ExpiredJwtException |
+               MalformedJwtException e) {
+        if (e instanceof ExpiredJwtException) {
+          response.setStatus(401);
+        } else {
+          response.setStatus(500);
+        }
+        response.flushBuffer();
+        return;
+      }
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/lion/studypartner/global/security/JwtProvider.java
+++ b/src/main/java/lion/studypartner/global/security/JwtProvider.java
@@ -1,0 +1,48 @@
+package lion.studypartner.global.security;
+
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtProvider {
+
+  private final SecretKey secretKey;
+  private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 3;
+  private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 7;
+
+
+  public JwtProvider(@Value("${spring.jwt.secret}") String secret) {
+    this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
+        Jwts.SIG.HS256.key().build().getAlgorithm());
+  }
+
+  public String createAccessToken(Long memberId, String email) {
+    return Jwts.builder()
+        .subject(email)
+        .claim("member_id", memberId)
+        .issuedAt(new Date())
+        .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
+        .signWith(secretKey)
+        .compact();
+  }
+
+  public String createRefreshToken(Long memberId, String email) {
+    return Jwts.builder()
+        .subject(email)
+        .claim("member_id", memberId)
+        .issuedAt(new Date())
+        .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME))
+        .signWith(secretKey)
+        .compact();
+  }
+
+  public String getEmail(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+        .getSubject();
+  }
+}

--- a/src/main/java/lion/studypartner/global/security/MemberDetail.java
+++ b/src/main/java/lion/studypartner/global/security/MemberDetail.java
@@ -1,0 +1,29 @@
+package lion.studypartner.global.security;
+
+import java.util.Collection;
+import java.util.List;
+import lion.studypartner.domain.member.dto.MemberResponse;
+import lombok.Data;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Data
+public class MemberDetail implements UserDetails {
+
+  private final MemberResponse member;
+
+  @Override
+  public String getUsername() {
+    return member.getEmail();
+  }
+
+  @Override
+  public String getPassword() {
+    return null;
+  }
+
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of(new SimpleGrantedAuthority("email" + member.getEmail()));
+  }
+}

--- a/src/main/java/lion/studypartner/global/security/MemberDetailService.java
+++ b/src/main/java/lion/studypartner/global/security/MemberDetailService.java
@@ -1,0 +1,26 @@
+package lion.studypartner.global.security;
+
+import lion.studypartner.domain.member.dto.MemberResponse;
+import lion.studypartner.domain.member.entity.Member;
+import lion.studypartner.domain.member.repository.MemberRepository;
+import lion.studypartner.global.expeciton.CustomException;
+import lion.studypartner.global.expeciton.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDetailService implements UserDetailsService {
+
+  private final MemberRepository memberRepository;
+
+  @Override
+  public MemberDetail loadUserByUsername(String email) {
+
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new CustomException(ErrorCode.EMAIL_EXIST));
+
+    return new MemberDetail(MemberResponse.from(member));
+  }
+}

--- a/src/main/java/lion/studypartner/global/security/TokenDto.java
+++ b/src/main/java/lion/studypartner/global/security/TokenDto.java
@@ -1,0 +1,12 @@
+package lion.studypartner.global.security;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenDto {
+
+  private String accessToken;
+  private String refreshToken;
+}

--- a/src/main/java/lion/studypartner/global/type/EducationType.java
+++ b/src/main/java/lion/studypartner/global/type/EducationType.java
@@ -1,0 +1,9 @@
+package lion.studypartner.global.type;
+
+public enum EducationType {
+  HIGH_SCHOOL,
+  UNIVERSITY,
+  GRADUATE_SCHOOL,
+  WORKING_PROFESSIONAL,
+  FREELANCER
+}

--- a/src/test/java/lion/studypartner/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/lion/studypartner/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,161 @@
+package lion.studypartner.domain.member.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import lion.studypartner.global.security.TokenDto;
+import org.springframework.http.MediaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.Date;
+import lion.studypartner.domain.member.dto.MemberRequest;
+import lion.studypartner.domain.member.dto.MemberResponse;
+import lion.studypartner.domain.member.service.MemberService;
+import lion.studypartner.global.type.EducationType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WithMockUser
+@WebMvcTest(MemberController.class)
+public class MemberControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private MemberService memberService;
+
+  private MemberRequest.SignUp signUpRequest;
+  private MemberResponse memberResponse;
+  private MemberRequest.SignIn signInRequest;
+
+  @BeforeEach
+  void setUp() {
+    this.signUpRequest = MemberRequest.SignUp.builder()
+        .name("test")
+        .email("test@email.com")
+        .password("!123Test")
+        .birthDate(new Date())
+        .education(EducationType.UNIVERSITY)
+        .alarmEnabled(true)
+        .build();
+
+    this.memberResponse = MemberResponse.builder()
+        .id(1L)
+        .name("test")
+        .email("test@email.com")
+        .birthDate(new Date())
+        .alarmEnabled(true)
+        .imageUrl("test.url")
+        .education(EducationType.UNIVERSITY)
+        .createdAt(LocalDateTime.of(2023, 1, 1, 10, 0))
+        .updatedAt(LocalDateTime.of(2023, 1, 1, 10, 0))
+        .deletedAt(null)
+        .build();
+
+    signInRequest = MemberRequest.SignIn.builder()
+        .email("test@email.com")
+        .password("!123Test")
+        .build();
+  }
+
+  @Test
+  @DisplayName("회원가입 성공")
+  void successSignUp() throws Exception {
+    // given
+    given(memberService.signUp(any(MemberRequest.SignUp.class)))
+        .willReturn(memberResponse);
+
+    // when & then
+    mockMvc.perform(post("/api/members/signup")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(new ObjectMapper().writeValueAsString(signUpRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.name").value("test"))
+        .andExpect(jsonPath("$.email").value("test@email.com"))
+        .andExpect(jsonPath("$.alarmEnabled").value(true))
+        .andExpect(jsonPath("$.imageUrl").value("test.url"))
+        .andExpect(jsonPath("$.education").value("UNIVERSITY"))
+        .andExpect(jsonPath("$.createdAt").value("2023-01-01T10:00:00"))
+        .andExpect(jsonPath("$.updatedAt").value("2023-01-01T10:00:00"))
+        .andExpect(jsonPath("$.deletedAt").doesNotExist())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("회원가입 실패 - 유효하지 않은 이메일")
+  void failSignUp() throws Exception {
+    // given
+    signUpRequest = MemberRequest.SignUp.builder()
+        .name("test")
+        .email("FALSE-email")
+        .password("!123Test")
+        .birthDate(new Date())
+        .education(EducationType.UNIVERSITY)
+        .alarmEnabled(true)
+        .build();
+
+    // when & then
+    mockMvc.perform(post("/api/members/signup")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(new ObjectMapper().writeValueAsString(signUpRequest)))
+        .andExpect(status().isBadRequest())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("로그인 성공")
+  void successSignIn() throws Exception {
+    // given
+    TokenDto tokenDto = TokenDto.builder()
+        .accessToken("access-token")
+        .refreshToken("refresh-token")
+        .build();
+
+    given(memberService.signIn(any(MemberRequest.SignIn.class))).willReturn(tokenDto);
+
+    // when & then
+    mockMvc.perform(post("/api/members/signin")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(new ObjectMapper().writeValueAsString(signInRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").value("access-token"))
+        .andExpect(jsonPath("$.refreshToken").value("refresh-token"))
+        .andDo(print());
+  }
+
+
+  @Test
+  @DisplayName("로그인 실패 - 비밀번호 누락")
+  void failSignIn_PasswordNull() throws Exception {
+
+    //given
+    signInRequest = MemberRequest.SignIn.builder()
+        .email("test@email.com")
+        .password(null)  // 비밀번호 누락
+        .build();
+
+    // when & then
+    mockMvc.perform(post("/api/members/signin")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(new ObjectMapper().writeValueAsString(signInRequest)))
+        .andExpect(status().isBadRequest())
+        .andDo(print());
+  }
+}

--- a/src/test/java/lion/studypartner/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/lion/studypartner/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,167 @@
+package lion.studypartner.domain.member.service;
+
+import lion.studypartner.domain.member.dto.MemberRequest;
+import lion.studypartner.domain.member.dto.MemberResponse;
+import lion.studypartner.domain.member.entity.Member;
+import lion.studypartner.domain.member.repository.MemberRepository;
+import lion.studypartner.global.expeciton.CustomException;
+import lion.studypartner.global.expeciton.ErrorCode;
+import lion.studypartner.global.security.JwtProvider;
+import lion.studypartner.global.security.TokenDto;
+import lion.studypartner.global.type.EducationType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Date;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+  @InjectMocks
+  private MemberService memberService;
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private BCryptPasswordEncoder passwordEncoder;
+
+  @Mock
+  private JwtProvider jwtProvider;
+
+  private MemberRequest.SignUp signUpRequest;
+
+  private MemberRequest.SignIn signInRequest;
+
+  private Member member;
+
+  @BeforeEach
+  void setUp() {
+    signUpRequest = MemberRequest.SignUp.builder()
+        .name("test")
+        .email("test@email.com")
+        .password("!123Test")
+        .birthDate(new Date())
+        .education(EducationType.UNIVERSITY)
+        .alarmEnabled(true)
+        .build();
+
+    signInRequest = MemberRequest.SignIn.builder()
+        .email("test@email.com")
+        .password("!123Test")
+        .build();
+
+    member = Member.builder()
+        .id(1L)
+        .email("test@email.com")
+        .password("encoded-password")
+        .name("test")
+        .birthDate(new Date())
+        .education(EducationType.UNIVERSITY)
+        .alarmEnabled(true)
+        .build();
+  }
+
+  @Test
+  @DisplayName("회원가입 성공")
+  void successSignUp() {
+    // given
+    when(memberRepository.findByEmail(signUpRequest.getEmail())).thenReturn(Optional.empty());
+    when(passwordEncoder.encode(signUpRequest.getPassword())).thenReturn("password");
+
+    Member savedMember = Member.builder()
+        .id(1L)
+        .name(signUpRequest.getName())
+        .email(signUpRequest.getEmail())
+        .password("password")
+        .birthDate(signUpRequest.getBirthDate())
+        .education(signUpRequest.getEducation())
+        .alarmEnabled(signUpRequest.isAlarmEnabled())
+        .build();
+
+    when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+
+    // when
+    MemberResponse response = memberService.signUp(signUpRequest);
+
+    // then
+    assertEquals(savedMember.getId(), response.getId());
+    assertEquals(savedMember.getName(), response.getName());
+    assertEquals(savedMember.getEmail(), response.getEmail());
+    assertEquals(savedMember.getBirthDate(), response.getBirthDate());
+    assertEquals(savedMember.getEducation(), response.getEducation());
+    assertEquals(savedMember.isAlarmEnabled(), response.isAlarmEnabled());
+  }
+
+  @Test
+  @DisplayName("회원가입 실패 - 이메일 중복")
+  void failSignUp_DuplicateEmail() {
+    // given
+    Member existingMember = Member.builder()
+        .id(1L)
+        .name("test")
+        .email(signUpRequest.getEmail())
+        .password("password")
+        .birthDate(signUpRequest.getBirthDate())
+        .education(signUpRequest.getEducation())
+        .alarmEnabled(signUpRequest.isAlarmEnabled())
+        .build();
+
+    when(memberRepository.findByEmail(signUpRequest.getEmail()))
+        .thenReturn(Optional.of(existingMember));
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () -> memberService.signUp(signUpRequest));
+
+    assertEquals(ErrorCode.EMAIL_EXIST, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("로그인 성공")
+  void successSignIn() {
+    // given
+    when(memberRepository.findByEmail(signInRequest.getEmail()))
+        .thenReturn(Optional.of(member));
+    when(passwordEncoder.matches(signInRequest.getPassword(), member.getPassword()))
+        .thenReturn(true);
+    when(jwtProvider.createAccessToken(member.getId(), member.getEmail()))
+        .thenReturn("access-token");
+    when(jwtProvider.createRefreshToken(member.getId(), member.getEmail()))
+        .thenReturn("refresh-token");
+
+    // when
+    TokenDto result = memberService.signIn(signInRequest);
+
+    // then
+    assertEquals("access-token", result.getAccessToken());
+    assertEquals("refresh-token", result.getRefreshToken());
+    verify(memberRepository).save(any(Member.class));  // refreshToken 저장 확인
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 존재하지 않는 이메일")
+  void failSignIn_emailNotFound() {
+    // given
+    when(memberRepository.findByEmail(signInRequest.getEmail()))
+        .thenReturn(Optional.empty());
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () -> memberService.signIn(signInRequest));
+
+    assertEquals(ErrorCode.LOGIN_FAIL, exception.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 변경사항
- 회원가입 및 로그인 기능 구현
  - MemberController
     - /api/members/signup : 회원가입 요청 처리 API 추가
     - /api/members/signin : 로그인 요청 처리 API 추가
  - MemberService
     - 회원가입 시 이메일 중복 체크 및 비밀번호 암호화 후 저장 처리
     - 로그인 시 이메일과 비밀번호 검증 후 JWT 토큰(access, refresh) 생성 및 저장 처리
  - MemberRequest DTO
     - 회원가입(SignUp)과 로그인(SignIn)에 필요한 요청 데이터 정의 및 유효성 검사 추가
  - MemberResponse DTO
     - 회원 엔티티를 기반으로 응답용 데이터 매핑 처리
  - Member 엔티티
     - 회원 정보를 DB 엔티티로 구현
     - Soft delete를 위한 deletedAt 필드 및 Hibernate의 @SQLDelete 어노테이션 적용
  - SecurityConfig
     - JWT 인증 필터 추가 및 시큐리티 설정
     - BCryptPasswordEncoder 빈 등록
  - JWT 관련 클래스 (JwtProvider, JwtFilter, MemberDetail, MemberDetailService)
     - JWT 토큰 생성, 검증 및 Spring Security 통합 구현
  - CustomException 및 ErrorCode
     - 예외 처리 통일 및 에러 코드 정의
  - 테스트 코드
     - MemberControllerTest: 회원가입 및 로그인 API 정상/비정상 시나리오 테스트
     - MemberServiceTest: 서비스 로직 단위 테스트(회원가입 성공/실패, 로그인 성공/실패)

**AS-IS**
- 회원기능 추후 더 깔끔하게 리팩토링 진행하겠습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

